### PR TITLE
Add rustfmt checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
       - name: Login to GHCR
         uses: docker/login-action@v3.4.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,6 @@ For the commit message please use conventional commits:
 
 Please test your code, build the parts of the application you touched. For example, if you made changes in the frontend, make sure to run `yarn build` and see if the build succeeds and maybe check out how it will look in prod via `yarn start`. Sometimes there is a difference between running `dev` and `start` & `build`.
 
-Make sure you format the files you created or touched. We use prettier for formatting, so either run the command `yarn run prettier` or install the fitting extension for your preferred IDE.
+Make sure you format the files you created or touched. We use prettier for formatting the frontend, so either run the command `yarn run prettier` or install the fitting extension for your preferred IDE. For Rust code run `cargo fmt` to keep the style consistent.
 
 When opening a Pull Request please select `develop` as the target branch.


### PR DESCRIPTION
## Summary
- install Rust toolchain with `rustfmt` in `release.yaml`
- enforce formatting via `cargo fmt` in CI
- mention `cargo fmt` in contributing docs

## Testing
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*
- `cargo fmt --all` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850b3cac3bc832ab6943785a91eb4b5