### PR TITLE
Add dashboard analytics charts

### DIFF
--- a/dash/.env.example
+++ b/dash/.env.example
@@ -2,6 +2,7 @@
 
 NEXT_PUBLIC_LIVE_URL=http://localhost:4000
 API_URL=http://localhost:4001
+NEXT_PUBLIC_ANALYTICS_URL=http://localhost:4002
 
 # NEXT_PUBLIC_MAP_KEY=
 

--- a/dash/package.json
+++ b/dash/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@headlessui/react": "2.2.2",
+		"chart.js": "^4.5.0",
 		"clsx": "2.1.1",
 		"geist": "1.3.1",
 		"maplibre-gl": "5.4.0",
@@ -19,6 +20,7 @@
 		"next": "15.3.1",
 		"pako": "2.1.0",
 		"react": "19.1.0",
+		"react-chartjs-2": "^5.3.0",
 		"react-dom": "19.1.0",
 		"sharp": "0.34.1",
 		"zod": "3.23.8",

--- a/dash/src/app/dashboard/analytics/page.tsx
+++ b/dash/src/app/dashboard/analytics/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Line } from "react-chartjs-2";
+import {
+	Chart as ChartJS,
+	CategoryScale,
+	LinearScale,
+	PointElement,
+	LineElement,
+	Title,
+	Tooltip,
+	Legend,
+} from "chart.js";
+
+import { env } from "@/env";
+import { useDataStore } from "@/stores/useDataStore";
+import Select from "@/components/ui/Select";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+interface Laptime {
+	lap: number | null;
+	time: string;
+	laptime: number;
+}
+
+interface Gap {
+	time: string;
+	gap: number;
+}
+
+export default function AnalyticsPage() {
+	const drivers = useDataStore((state) => state.driverList);
+	const [driver, setDriver] = useState<string | null>(null);
+	const [laptimes, setLaptimes] = useState<Laptime[]>([]);
+	const [gaps, setGaps] = useState<Gap[]>([]);
+
+	useEffect(() => {
+		if (!driver) return;
+
+		(async () => {
+			try {
+				const [ltRes, gapRes] = await Promise.all([
+					fetch(`${env.NEXT_PUBLIC_ANALYTICS_URL}/api/laptime/${driver}`),
+					fetch(`${env.NEXT_PUBLIC_ANALYTICS_URL}/api/gap/${driver}`),
+				]);
+
+				if (ltRes.ok) {
+					const data: Laptime[] = await ltRes.json();
+					setLaptimes(data);
+				}
+				if (gapRes.ok) {
+					const data: Gap[] = await gapRes.json();
+					setGaps(data);
+				}
+			} catch (e) {
+				console.error("failed to fetch analytics", e);
+			}
+		})();
+	}, [driver]);
+
+	const driverOptions = drivers
+		? Object.values(drivers).map((d) => ({ label: d.fullName, value: d.racingNumber }))
+		: [];
+
+	const laptimeData = {
+		labels: laptimes.map((l) => l.lap ?? 0),
+		datasets: [
+			{
+				label: "Lap Time (ms)",
+				data: laptimes.map((l) => l.laptime),
+				borderColor: "rgb(75, 192, 192)",
+				backgroundColor: "rgba(75, 192, 192, 0.4)",
+			},
+		],
+	};
+
+	const gapData = {
+		labels: gaps.map((g) => new Date(g.time).toLocaleTimeString()),
+		datasets: [
+			{
+				label: "Gap to Leader (ms)",
+				data: gaps.map((g) => g.gap),
+				borderColor: "rgb(255, 99, 132)",
+				backgroundColor: "rgba(255, 99, 132, 0.4)",
+			},
+		],
+	};
+
+	return (
+		<div className="flex flex-col gap-4 p-4">
+			<div className="w-64">
+				<Select placeholder="Select driver" options={driverOptions} selected={driver} setSelected={setDriver} />
+			</div>
+
+			{driver && (
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<Line data={laptimeData} />
+					<Line data={gapData} />
+				</div>
+			)}
+		</div>
+	);
+}

--- a/dash/src/components/Sidebar.tsx
+++ b/dash/src/components/Sidebar.tsx
@@ -35,6 +35,10 @@ const liveTimingItems = [
 		href: "/dashboard/weather",
 		name: "Weather",
 	},
+	{
+		href: "/dashboard/analytics",
+		name: "Analytics",
+	},
 ];
 
 type Props = {
@@ -58,7 +62,7 @@ export default function Sidebar({ connected }: Props) {
 
 	const pin = useSidebarStore((state) => state.pin);
 	const unpin = useSidebarStore((state) => state.unpin);
-	
+
 	const oledMode = useSettingsStore((state) => state.oledMode);
 
 	useEffect(() => {

--- a/dash/src/env-script.tsx
+++ b/dash/src/env-script.tsx
@@ -8,6 +8,7 @@ import { PUBLIC_ENV_KEY } from "@/env";
 export const getPublicEnv = () => ({
 	NEXT_PUBLIC_LIVE_URL: process.env.NEXT_PUBLIC_LIVE_URL,
 	NEXT_PUBLIC_MAP_KEY: process.env.NEXT_PUBLIC_MAP_KEY,
+	NEXT_PUBLIC_ANALYTICS_URL: process.env.NEXT_PUBLIC_ANALYTICS_URL,
 });
 
 export default async function EnvScript() {

--- a/dash/src/env.ts
+++ b/dash/src/env.ts
@@ -13,6 +13,7 @@ const server = z.object({
 
 const client = z.object({
 	NEXT_PUBLIC_LIVE_URL: z.string().min(1).includes("http"),
+	NEXT_PUBLIC_ANALYTICS_URL: z.string().min(1).includes("http"),
 });
 
 const processEnv = {
@@ -26,6 +27,7 @@ const processEnv = {
 	DISABLE_IFRAME: process.env.DISABLE_IFRAME,
 
 	NEXT_PUBLIC_LIVE_URL: process.env.NEXT_PUBLIC_LIVE_URL,
+	NEXT_PUBLIC_ANALYTICS_URL: process.env.NEXT_PUBLIC_ANALYTICS_URL,
 };
 
 // Don't touch the part below

--- a/dash/yarn.lock
+++ b/dash/yarn.lock
@@ -414,6 +414,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kurkle/color@npm:^0.3.0":
+  version: 0.3.4
+  resolution: "@kurkle/color@npm:0.3.4"
+  checksum: 10c0/0e9fd55c614b005c5f0c4c755bca19ec0293bc7513b4ea3ec1725234f9c2fa81afbc78156baf555c8b9cb0d305619253c3f5bca016067daeebb3d00ebb4ea683
+  languageName: node
+  linkType: hard
+
 "@mapbox/geojson-rewind@npm:^0.5.2":
   version: 0.5.2
   resolution: "@mapbox/geojson-rewind@npm:0.5.2"
@@ -1539,6 +1546,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chart.js@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "chart.js@npm:4.5.0"
+  dependencies:
+    "@kurkle/color": "npm:^0.3.0"
+  checksum: 10c0/f12c7f9a238ee7ce6d3f7111628e9daba86bb8ff8e54cfe63525fde6ded9003c72c4c8d2c7d5702539dc0aff7e682dfec058660ade8d03a970da002656d4ac91
+  languageName: node
+  linkType: hard
+
 "client-only@npm:0.0.1":
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
@@ -2200,6 +2216,7 @@ __metadata:
     "@types/pako": "npm:2.0.3"
     "@types/react": "npm:19.0.10"
     "@types/react-dom": "npm:19.0.4"
+    chart.js: "npm:^4.5.0"
     clsx: "npm:2.1.1"
     eslint: "npm:9.25.1"
     eslint-config-next: "npm:15.3.1"
@@ -2213,6 +2230,7 @@ __metadata:
     prettier: "npm:3.5.3"
     prettier-plugin-tailwindcss: "npm:0.6.11"
     react: "npm:19.1.0"
+    react-chartjs-2: "npm:^5.3.0"
     react-dom: "npm:19.1.0"
     sharp: "npm:0.34.1"
     tailwindcss: "npm:4.0.8"
@@ -3753,6 +3771,16 @@ __metadata:
   version: 3.0.0
   resolution: "quickselect@npm:3.0.0"
   checksum: 10c0/3a0d33b0ec06841d953accdfd735aa3d8b7922cddd12970544a2c4b0278871280d8f5ba496803600693c1e7b7b2fb57c31d2b14d99132f478888006a1be6e6b7
+  languageName: node
+  linkType: hard
+
+"react-chartjs-2@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "react-chartjs-2@npm:5.3.0"
+  peerDependencies:
+    chart.js: ^4.1.1
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/4415d40217c084a49f9a936fbd30f67e0e705148e6f8359bec65601033d1076f31085c45793839fc29ec833e6c427b0bf9861a0c54c432c08d35bc9590ffa41a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add Chart.js and react-chartjs-2
- expose NEXT_PUBLIC_ANALYTICS_URL env variable
- add analytics link to sidebar
- create new `/dashboard/analytics` page for lap time and gap charts

## Testing
- `yarn prettier`
- `NEXT_PUBLIC_LIVE_URL=http://localhost:4000 API_URL=http://localhost:4001 NEXT_PUBLIC_ANALYTICS_URL=http://localhost:4002 yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6850b5af73f4832a99d92ba0135b931d