### PR TITLE
Add circle map toggle

### DIFF
--- a/dash/src/app/dashboard/track-map/page.tsx
+++ b/dash/src/app/dashboard/track-map/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
 import clsx from "clsx";
 
 import Map from "@/components/dashboard/Map";
+import CircleMap from "@/components/dashboard/CircleMap";
+import Toggle from "@/components/ui/Toggle";
 import DriverTag from "@/components/driver/DriverTag";
 import DriverDRS from "@/components/driver/DriverDRS";
 import DriverInfo from "@/components/driver/DriverInfo";
@@ -17,8 +20,9 @@ import type { Driver, TimingDataDriver } from "@/types/state.type";
 import { useSettingsStore } from "@/stores/useSettingsStore";
 
 export default function TrackMap() {
-	const drivers = useDataStore((state) => state?.driverList);
-	const driversTiming = useDataStore((state) => state?.timingData);
+        const drivers = useDataStore((state) => state?.driverList);
+        const driversTiming = useDataStore((state) => state?.timingData);
+        const [showCircle, setShowCircle] = useState(false);
 
 	return (
 		<div className="flex flex-col-reverse md:h-full md:flex-row">
@@ -42,11 +46,14 @@ export default function TrackMap() {
 				)}
 			</div>
 
-			<div className="md:flex-1">
-				<Map />
-			</div>
-		</div>
-	);
+                        <div className="md:flex-1">
+                                <div className="flex justify-end p-2">
+                                        <Toggle enabled={showCircle} setEnabled={setShowCircle} />
+                                </div>
+                                {showCircle ? <CircleMap /> : <Map />}
+                        </div>
+                </div>
+        );
 }
 
 type TrackMapDriverProps = {

--- a/dash/src/components/dashboard/CircleMap.tsx
+++ b/dash/src/components/dashboard/CircleMap.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useState } from "react";
+import type { PositionCar } from "@/types/state.type";
+import type { TrackPosition } from "@/types/map.type";
+import { polarToCartesian } from "@/lib/circle";
+import { fetchMap } from "@/lib/fetchMap";
+import { useDataStore, usePositionStore } from "@/stores/useDataStore";
+import { rotate, findMinDistance } from "@/lib/map";
+
+export default function CircleMap() {
+    const positions = usePositionStore((state) => state.positions);
+    const drivers = useDataStore((state) => state?.driverList);
+    const timingData = useDataStore((state) => state?.timingData);
+    const circuitKey = useDataStore((state) => state?.sessionInfo?.meeting.circuit.key);
+
+    const [points, setPoints] = useState<TrackPosition[] | null>(null);
+    const [center, setCenter] = useState<[number, number]>([0, 0]);
+    const [rotation, setRotation] = useState<number>(0);
+
+    useEffect(() => {
+        (async () => {
+            if (!circuitKey) return;
+            const mapJson = await fetchMap(circuitKey);
+            if (!mapJson) return;
+            const centerX = (Math.max(...mapJson.x) - Math.min(...mapJson.x)) / 2;
+            const centerY = (Math.max(...mapJson.y) - Math.min(...mapJson.y)) / 2;
+            const fixedRotation = mapJson.rotation + 90;
+            const rotatedPoints = mapJson.x.map((x, index) => rotate(x, mapJson.y[index], fixedRotation, centerX, centerY));
+            setPoints(rotatedPoints);
+            setCenter([centerX, centerY]);
+            setRotation(fixedRotation);
+        })();
+    }, [circuitKey]);
+
+    const driverAngles = useMemo(() => {
+        if (!points || !positions || !drivers)
+            return [] as { angle: number; nr: string; color: string | undefined; tla: string; gap?: string }[];
+
+        return Object.values(drivers)
+            .filter((d) => positions[d.racingNumber])
+            .map((d) => {
+                const pos = positions[d.racingNumber] as PositionCar;
+                const rotated = rotate(pos.X, pos.Y, rotation, center[0], center[1]);
+                const idx = findMinDistance(rotated, points);
+                const progress = idx / points.length;
+                const angle = progress * 360;
+                const gap = timingData?.lines[d.racingNumber]?.intervalToPositionAhead?.value;
+                return { angle, nr: d.racingNumber, color: d.teamColour, tla: d.tla, gap };
+            })
+            .sort((a, b) => a.angle - b.angle);
+    }, [points, positions, drivers, timingData, rotation, center]);
+
+    if (!points) {
+        return (
+            <div className="h-full w-full p-2" style={{ minHeight: "35rem" }}>
+                <div className="h-full w-full animate-pulse rounded-lg bg-zinc-800" />
+            </div>
+        );
+    }
+
+    const size = 200;
+    const centerXY = size / 2;
+    const radius = centerXY - 20;
+
+    return (
+        <svg viewBox={`0 0 ${size} ${size}`} className="h-full w-full xl:max-h-screen" xmlns="http://www.w3.org/2000/svg">
+            <circle cx={centerXY} cy={centerXY} r={radius} className="stroke-zinc-700" fill="transparent" strokeWidth={2} />
+            {driverAngles.map((d) => {
+                const pos = polarToCartesian(centerXY, centerXY, radius, d.angle);
+                return (
+                    <g key={`circle.driver.${d.nr}`}> 
+                        <circle cx={pos.x} cy={pos.y} r={4} fill={d.color ? `#${d.color}` : "#fff"} />
+                        <text x={pos.x} y={pos.y - 6} textAnchor="middle" fontSize="10" className="fill-zinc-300">
+                            {d.tla}
+                        </text>
+                    </g>
+                );
+            })}
+            {driverAngles.map((d, idx) => {
+                if (!d.gap) return null;
+                const prev = idx === 0 ? driverAngles[driverAngles.length - 1] : driverAngles[idx - 1];
+                let mid = (prev.angle + d.angle) / 2;
+                if (idx === 0) {
+                    const diff = d.angle + 360 - prev.angle;
+                    mid = prev.angle + diff / 2;
+                }
+                const pos = polarToCartesian(centerXY, centerXY, radius + 12, mid);
+                return (
+                    <text key={`gap.${d.nr}`} x={pos.x} y={pos.y} textAnchor="middle" fontSize="8" className="fill-zinc-500">
+                        {d.gap}
+                    </text>
+                );
+            })}
+        </svg>
+    );
+}


### PR DESCRIPTION
## Summary
- create `CircleMap` component to show driver progress in a circle and gaps to the car in front
- add a toggle on the track map page to switch between normal and circle maps

## Testing
- `cargo test`
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6850b732cd64832a99356fde582ae739